### PR TITLE
reloading CouchDB views on Centos takes a long time

### DIFF
--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -14,7 +14,7 @@ admin_commands:
   component: npme
   image:
     image_name: npme
-    version: '1.0.25'
+    version: '1.0.26'
 - alias: reset-follower
   command: [sh, /etc/npme/reset-follower.sh]
   run_type: exec
@@ -42,7 +42,7 @@ admin_commands:
   component: npme
   image:
     image_name: npme
-    version: '1.0.25'
+    version: '1.0.26'
 state:
   ready: null
 backup:
@@ -349,7 +349,7 @@ components:
     support_files: []
   - source: replicated
     image_name: npme
-    version: '1.0.25'
+    version: '1.0.26'
     privileged: false
     restart:
       policy: on-failure

--- a/replicated/start.sh
+++ b/replicated/start.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env sh
 chmod 755 /etc/npme/install-couch-app.sh
-sh /etc/npme/install-couch-app.sh
+
+curl --fail -XGET $COUCH_URL
+ret=$?
+if [ $ret -ne 0 ]; then
+  sh /etc/npme/install-couch-app.sh
+fi
 
 curl --fail -XGET $COUCH_URL
 ret=$?


### PR DESCRIPTION
Reloading the couch views on Centos takes a long time, and there's no reason to do this if the `/registry` endpoint already exists. Let's be smarter and only install the registry couch-app if it's needed.