### PR TITLE
Bump Node to 4 for newww

### DIFF
--- a/replicated/newww/Dockerfile
+++ b/replicated/newww/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM mhart/alpine-node:0.10.40
+FROM mhart/alpine-node:4.2.3
 
 # File Author / Maintainer
 MAINTAINER Ben Coe


### PR DESCRIPTION
As of `newww@4.0.0`, Node 4+ is required.

I tested this locally with `@nexdrew/newww`.