### PR TITLE
link the npm-explicit-installs module

### DIFF
--- a/replicated/newww/Dockerfile
+++ b/replicated/newww/Dockerfile
@@ -6,6 +6,7 @@ MAINTAINER Ben Coe
 
 WORKDIR /etc/npme
 COPY ./replicated/newww/start.sh /etc/npme/start.sh
+COPY ./replicated/newww/homepage.sh /etc/npme/homepage.sh
 
 RUN echo '@npm:registry=https://enterprise.npmjs.com/' > ~/.npmrc
 RUN apk update

--- a/replicated/newww/Dockerfile
+++ b/replicated/newww/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add python
 RUN apk add make
 RUN apk add g++
 RUN npm install node-gyp -g
-RUN npm install newww@next
+RUN npm install newww
 RUN npm install @npm/npmo-auth-callbacks
 RUN apk del python
 RUN apk del make

--- a/replicated/newww/Dockerfile
+++ b/replicated/newww/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add python
 RUN apk add make
 RUN apk add g++
 RUN npm install node-gyp -g
-RUN npm install newww
+RUN npm install newww@next
 RUN npm install @npm/npmo-auth-callbacks
 RUN apk del python
 RUN apk del make

--- a/replicated/newww/homepage.sh
+++ b/replicated/newww/homepage.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+cd /etc/npme/data/npm-explicit-installs
+node ./bin/npm-explicit-installs.js $@

--- a/replicated/newww/start.sh
+++ b/replicated/newww/start.sh
@@ -2,6 +2,7 @@
 
 if [ ! -d "/etc/npme/data/npm-explicit-installs" ]; then
   mv /etc/npme/node_modules/newww/node_modules/npm-explicit-installs /etc/npme/data/npm-explicit-installs
+  cd /etc/npme/data/npm-explicit-installs; npm i
   ln -s /etc/npme/data/npm-explicit-installs /etc/npme/node_modules/newww/node_modules/npm-explicit-installs
 fi
 

--- a/replicated/newww/start.sh
+++ b/replicated/newww/start.sh
@@ -2,7 +2,7 @@
 
 if [ ! -d "/etc/npme/data/npm-explicit-installs" ]; then
   mv /etc/npme/node_modules/newww/node_modules/npm-explicit-installs /etc/npme/data/npm-explicit-installs
-  cd /etc/npme/data/npm-explicit-installs; npm i --production
+  cd /etc/npme/data/npm-explicit-installs; rm -rf node_modules; npm i --production
 fi
 rm -rf /etc/npme/node_modules/newww/node_modules/npm-explicit-installs
 ln -f -s /etc/npme/data/npm-explicit-installs /etc/npme/node_modules/newww/node_modules

--- a/replicated/newww/start.sh
+++ b/replicated/newww/start.sh
@@ -3,8 +3,9 @@
 if [ ! -d "/etc/npme/data/npm-explicit-installs" ]; then
   mv /etc/npme/node_modules/newww/node_modules/npm-explicit-installs /etc/npme/data/npm-explicit-installs
   cd /etc/npme/data/npm-explicit-installs; npm i --production
-  ln -s /etc/npme/data/npm-explicit-installs /etc/npme/node_modules/newww/node_modules/npm-explicit-installs
 fi
+rm -rf /etc/npme/node_modules/newww/node_modules/npm-explicit-installs
+ln -f -s /etc/npme/data/npm-explicit-installs /etc/npme/node_modules/newww/node_modules
 
 { cd /etc/npme/node_modules/newww; node server.js; } &
 { cd /etc/npme/node_modules/@npm/npmo-auth-callbacks; node bin/npmo-auth-callbacks.js start --certificate=$CERTIFICATE --redis=$REDIS_URL --entity-id=$ENTITY_ID --assert-endpoint=$ASSERT_ENDPOINT --logout-endpoint=$LOGOUT_ENDPOINT --nameid-format=$NAMEID_FORMAT --sso-login-url=$SSO_LOGIN_URL --sso-logout-url=$SSO_LOGOUT_URL; } &

--- a/replicated/newww/start.sh
+++ b/replicated/newww/start.sh
@@ -4,6 +4,10 @@ if [ ! -d "/etc/npme/data/npm-explicit-installs" ]; then
   mv /etc/npme/node_modules/newww/node_modules/npm-explicit-installs /etc/npme/data/npm-explicit-installs
   cd /etc/npme/data/npm-explicit-installs; rm -rf node_modules; npm i --production
 fi
+# whenever we boot a new copy of the docker image, we remove the
+# base copy of npm-explicit-installs and replace it with a copy
+# that is linked on the host machine. This allows permanent edits
+# to be made to the package listing page.
 rm -rf /etc/npme/node_modules/newww/node_modules/npm-explicit-installs
 ln -f -s /etc/npme/data/npm-explicit-installs /etc/npme/node_modules/newww/node_modules
 

--- a/replicated/newww/start.sh
+++ b/replicated/newww/start.sh
@@ -2,7 +2,7 @@
 
 if [ ! -d "/etc/npme/data/npm-explicit-installs" ]; then
   mv /etc/npme/node_modules/newww/node_modules/npm-explicit-installs /etc/npme/data/npm-explicit-installs
-  cd /etc/npme/data/npm-explicit-installs; npm i
+  cd /etc/npme/data/npm-explicit-installs; npm i --production
   ln -s /etc/npme/data/npm-explicit-installs /etc/npme/node_modules/newww/node_modules/npm-explicit-installs
 fi
 

--- a/replicated/newww/start.sh
+++ b/replicated/newww/start.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-if [ ! -d "/etc/npme/data/npm-explicit-installs" ]; then
-  mv /etc/npme/node_modules/newww/node_modules/npm-explicit-installs /etc/npme/data/npm-explicit-installs
-  cd /etc/npme/data/npm-explicit-installs; rm -rf node_modules; npm i --production
-fi
 # whenever we boot a new copy of the docker image, we remove the
 # base copy of npm-explicit-installs and replace it with a copy
 # that is linked on the host machine. This allows permanent edits
 # to be made to the package listing page.
+if [ ! -d "/etc/npme/data/npm-explicit-installs" ]; then
+  mv /etc/npme/node_modules/newww/node_modules/npm-explicit-installs /etc/npme/data/npm-explicit-installs
+  # we need to re-install because of shared dependencies and npm@3.x's deduping.
+  cd /etc/npme/data/npm-explicit-installs; rm -rf node_modules; npm i --production
+fi
 rm -rf /etc/npme/node_modules/newww/node_modules/npm-explicit-installs
 ln -f -s /etc/npme/data/npm-explicit-installs /etc/npme/node_modules/newww/node_modules
 

--- a/replicated/newww/start.sh
+++ b/replicated/newww/start.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ ! -d "/etc/npme/data/npm-explicit-installs" ]; then
+  mv /etc/npme/node_modules/newww/node_modules/npm-explicit-installs /etc/npme/data/npm-explicit-installs
+  ln -s /etc/npme/data/npm-explicit-installs /etc/npme/node_modules/newww/node_modules/npm-explicit-installs
+fi
+
 { cd /etc/npme/node_modules/newww; node server.js; } &
 { cd /etc/npme/node_modules/@npm/npmo-auth-callbacks; node bin/npmo-auth-callbacks.js start --certificate=$CERTIFICATE --redis=$REDIS_URL --entity-id=$ENTITY_ID --assert-endpoint=$ASSERT_ENDPOINT --logout-endpoint=$LOGOUT_ENDPOINT --nameid-format=$NAMEID_FORMAT --sso-login-url=$SSO_LOGIN_URL --sso-logout-url=$SSO_LOGOUT_URL; } &
 wait -n

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -43,6 +43,13 @@ admin_commands:
   image:
     image_name: policy-follower
     version: '1.0.17'
+- alias: edit-homepage
+  command: [sh, /etc/npme/homepage.sh]
+  run_type: exec
+  component: npme
+  image:
+    image_name: newww
+    version: '1.1.0'
 - alias: ssh
   run_type: exec
   command: [/bin/sh]
@@ -634,7 +641,7 @@ components:
     support_files: []
   - source: replicated
     image_name: newww
-    version: '1.0.12'
+    version: '1.1.0'
     privileged: false
     restart:
       policy: on-failure

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -634,7 +634,7 @@ components:
     support_files: []
   - source: replicated
     image_name: newww
-    version: '1.0.8'
+    version: '1.0.9'
     privileged: false
     restart:
       policy: on-failure

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -695,6 +695,12 @@ components:
         static_val: '{{repl ConfigOption "saml_sso_login_url" }}'
       - name: SSO_LOGOUT_URL
         static_val: '{{repl ConfigOption "saml_sso_logout_url" }}'
+      - name: COUCH_URL_REMOTE
+        static_val: '{{repl ConfigOption "couch_url_remote" }}'
+        is_excluded_from_support: true
+      - name: PROXY_URL
+        static_val: '{{repl ConfigOption "proxy_url" }}'
+        is_excluded_from_support: true
     ports:
       - private_port: "8081"
         public_port: "8081"

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -634,7 +634,7 @@ components:
     support_files: []
   - source: replicated
     image_name: newww
-    version: '1.0.11'
+    version: '1.0.12'
     privileged: false
     restart:
       policy: on-failure

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -634,7 +634,7 @@ components:
     support_files: []
   - source: replicated
     image_name: newww
-    version: '1.0.7'
+    version: '1.0.8'
     privileged: false
     restart:
       policy: on-failure
@@ -704,7 +704,9 @@ components:
         public_port: "8082"
         port_type: tcp
         when: ""
-    volumes: []
+    volumes:
+      - host_path: '{{repl ConfigOption "data_host_path" }}'
+        container_path: /etc/npme/data
     support_files: []
   - source: replicated
     image_name: es-follower

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -634,7 +634,7 @@ components:
     support_files: []
   - source: replicated
     image_name: newww
-    version: '1.0.10'
+    version: '1.0.11'
     privileged: false
     restart:
       policy: on-failure

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -634,7 +634,7 @@ components:
     support_files: []
   - source: replicated
     image_name: newww
-    version: '1.0.9'
+    version: '1.0.10'
     privileged: false
     restart:
       policy: on-failure


### PR DESCRIPTION
We now link the npm-explicit-installs module to a mounted folder, so that we can easily customize the content.