### PR TITLE
Bump minor base image versions

### DIFF
--- a/replicated/es-follower/Dockerfile
+++ b/replicated/es-follower/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM mhart/alpine-node:0.10.40
+FROM mhart/alpine-node:0.10.42
 
 # File Author / Maintainer
 MAINTAINER Ben Coe

--- a/replicated/newww/Dockerfile
+++ b/replicated/newww/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM mhart/alpine-node:4.2.3
+FROM mhart/alpine-node:4.3.0
 
 # File Author / Maintainer
 MAINTAINER Ben Coe

--- a/replicated/nginx/Dockerfile
+++ b/replicated/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.2
+FROM alpine:3.3
 RUN apk add --update nginx && rm -rf /var/cache/apk/*
 RUN mkdir -p /tmp/nginx/client-body
 

--- a/replicated/npm-auth-ws/Dockerfile
+++ b/replicated/npm-auth-ws/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM mhart/alpine-node:0.10.40
+FROM mhart/alpine-node:0.10.42
 
 # File Author / Maintainer
 MAINTAINER Ben Coe

--- a/replicated/policy-follower/Dockerfile
+++ b/replicated/policy-follower/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM mhart/alpine-node:0.10.40
+FROM mhart/alpine-node:0.10.42
 
 # File Author / Maintainer
 MAINTAINER Ben Coe

--- a/replicated/registry-follower/Dockerfile
+++ b/replicated/registry-follower/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM mhart/alpine-node:0.10.40
+FROM mhart/alpine-node:0.10.42
 
 # File Author / Maintainer
 MAINTAINER Ben Coe

--- a/replicated/registry-service/Dockerfile
+++ b/replicated/registry-service/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM mhart/alpine-node:0.10.40
+FROM mhart/alpine-node:0.10.42
 
 # File Author / Maintainer
 MAINTAINER Ben Coe

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -14,7 +14,7 @@ admin_commands:
   component: npme
   image:
     image_name: npm-auth-ws
-    version: '1.1.1'
+    version: '1.1.2'
 - alias: update-license
   command: [sh, /usr/local/bin/npme-update-license.sh]
   run_type: exec
@@ -28,28 +28,28 @@ admin_commands:
   component: npme
   image:
     image_name: policy-follower
-    version: '1.0.18'
+    version: '1.0.19'
 - alias: add-package
   command: [sh, /etc/npme/add-package.sh]
   run_type: exec
   component: npme
   image:
     image_name: policy-follower
-    version: '1.0.18'
+    version: '1.0.19'
 - alias: remove-package
   command: [sh, /etc/npme/remove-package.sh]
   run_type: exec
   component: npme
   image:
     image_name: policy-follower
-    version: '1.0.18'
+    version: '1.0.19'
 - alias: edit-homepage
   command: [sh, /etc/npme/homepage.sh]
   run_type: exec
   component: npme
   image:
     image_name: newww
-    version: '1.2.1'
+    version: '1.3.0'
 - alias: ssh
   run_type: exec
   command: [/bin/sh]
@@ -81,7 +81,7 @@ components:
   containers:
   - source: replicated
     image_name: nginx
-    version: '1.0.0'
+    version: '1.1.0'
     privileged: false
     restart:
       policy: on-failure
@@ -104,7 +104,7 @@ components:
     support_files: []
   - source: replicated
     image_name: npm-auth-ws
-    version: '1.1.1'
+    version: '1.1.2'
     privileged: false
     restart:
       policy: on-failure
@@ -170,7 +170,7 @@ components:
     support_files: []
   - source: replicated
     image_name: validate-and-store
-    version: '1.0.2'
+    version: '1.0.3'
     privileged: false
     restart:
       policy: on-failure
@@ -205,7 +205,7 @@ components:
     support_files: []
   - source: replicated
     image_name: policy-follower
-    version: '1.0.18'
+    version: '1.0.19'
     privileged: false
     restart:
       policy: on-failure
@@ -540,7 +540,7 @@ components:
     support_files: []
   - source: replicated
     image_name: rr
-    version: '1.0.1'
+    version: '1.0.2'
     privileged: false
     restart:
       policy: on-failure
@@ -606,7 +606,7 @@ components:
     support_files: []
   - source: replicated
     image_name: rr-service
-    version: '1.0.0'
+    version: '1.0.1'
     privileged: false
     restart:
       policy: on-failure
@@ -641,7 +641,7 @@ components:
     support_files: []
   - source: replicated
     image_name: newww
-    version: '1.2.1'
+    version: '1.3.0'
     privileged: false
     restart:
       policy: on-failure
@@ -728,7 +728,7 @@ components:
     support_files: []
   - source: replicated
     image_name: es-follower
-    version: '1.0.3'
+    version: '1.0.4'
     privileged: false
     restart:
       policy: on-failure

--- a/replicated/validate-and-store/Dockerfile
+++ b/replicated/validate-and-store/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM mhart/alpine-node:0.10.40
+FROM mhart/alpine-node:0.10.42
 
 # File Author / Maintainer
 MAINTAINER Ben Coe


### PR DESCRIPTION
Mainly to include recent [Node security releases](https://nodejs.org/en/blog/vulnerability/february-2016-security-releases/) and also just to keep things up-to-date.