### PR TITLE
Upgrade to Node 4.3.1

### DIFF
--- a/replicated/Dockerfile.replicated
+++ b/replicated/Dockerfile.replicated
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM mhart/alpine-node:4.2.1
+FROM mhart/alpine-node:4.3.1
 
 # File Author / Maintainer
 MAINTAINER Ben Coe

--- a/replicated/es-follower/Dockerfile
+++ b/replicated/es-follower/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM mhart/alpine-node:0.10.42
+FROM mhart/alpine-node:4.3.1
 
 # File Author / Maintainer
 MAINTAINER Ben Coe

--- a/replicated/newww/Dockerfile
+++ b/replicated/newww/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM mhart/alpine-node:4.3.0
+FROM mhart/alpine-node:4.3.1
 
 # File Author / Maintainer
 MAINTAINER Ben Coe

--- a/replicated/npm-auth-ws/Dockerfile
+++ b/replicated/npm-auth-ws/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM mhart/alpine-node:0.10.42
+FROM mhart/alpine-node:4.3.1
 
 # File Author / Maintainer
 MAINTAINER Ben Coe

--- a/replicated/policy-follower/Dockerfile
+++ b/replicated/policy-follower/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM mhart/alpine-node:0.10.42
+FROM mhart/alpine-node:4.3.1
 
 # File Author / Maintainer
 MAINTAINER Ben Coe

--- a/replicated/replicated.yml
+++ b/replicated/replicated.yml
@@ -14,49 +14,49 @@ admin_commands:
   component: npme
   image:
     image_name: npm-auth-ws
-    version: '1.1.2'
+    version: '2.0.0'
 - alias: update-license
   command: [sh, /usr/local/bin/npme-update-license.sh]
   run_type: exec
   component: npme
   image:
     image_name: npme
-    version: '1.0.30'
+    version: '1.1.0'
 - alias: reset-follower
   command: [sh, /etc/npme/reset-follower.sh]
   run_type: exec
   component: npme
   image:
     image_name: policy-follower
-    version: '1.0.19'
+    version: '2.0.0'
 - alias: add-package
   command: [sh, /etc/npme/add-package.sh]
   run_type: exec
   component: npme
   image:
     image_name: policy-follower
-    version: '1.0.19'
+    version: '2.0.0'
 - alias: remove-package
   command: [sh, /etc/npme/remove-package.sh]
   run_type: exec
   component: npme
   image:
     image_name: policy-follower
-    version: '1.0.19'
+    version: '2.0.0'
 - alias: edit-homepage
   command: [sh, /etc/npme/homepage.sh]
   run_type: exec
   component: npme
   image:
     image_name: newww
-    version: '1.3.0'
+    version: '1.3.1'
 - alias: ssh
   run_type: exec
   command: [/bin/sh]
   component: npme
   image:
     image_name: npme
-    version: '1.0.30'
+    version: '1.1.0'
 state:
   ready: null
 backup:
@@ -104,7 +104,7 @@ components:
     support_files: []
   - source: replicated
     image_name: npm-auth-ws
-    version: '1.1.2'
+    version: '2.0.0'
     privileged: false
     restart:
       policy: on-failure
@@ -170,7 +170,7 @@ components:
     support_files: []
   - source: replicated
     image_name: validate-and-store
-    version: '1.0.3'
+    version: '2.0.0'
     privileged: false
     restart:
       policy: on-failure
@@ -205,7 +205,7 @@ components:
     support_files: []
   - source: replicated
     image_name: policy-follower
-    version: '1.0.19'
+    version: '2.0.0'
     privileged: false
     restart:
       policy: on-failure
@@ -379,7 +379,7 @@ components:
     support_files: []
   - source: replicated
     image_name: npme
-    version: '1.0.30'
+    version: '1.1.0'
     privileged: false
     restart:
       policy: on-failure
@@ -641,7 +641,7 @@ components:
     support_files: []
   - source: replicated
     image_name: newww
-    version: '1.3.0'
+    version: '1.3.1'
     privileged: false
     restart:
       policy: on-failure
@@ -728,7 +728,7 @@ components:
     support_files: []
   - source: replicated
     image_name: es-follower
-    version: '1.0.4'
+    version: '2.0.0'
     privileged: false
     restart:
       policy: on-failure

--- a/replicated/validate-and-store/Dockerfile
+++ b/replicated/validate-and-store/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image to Ubuntu
-FROM mhart/alpine-node:0.10.42
+FROM mhart/alpine-node:4.3.1
 
 # File Author / Maintainer
 MAINTAINER Ben Coe


### PR DESCRIPTION
Fixes #41. See comments there.

For services already running on Node 4, bump to latest 4 version (4.3.1):

- npme (minor)
- newww (patch)

For services running Node 0.10 that are deemed ready for Node 4, bump to 4.3.1:

- es-follower (major)
- npm-auth-ws (major)
- policy-follower (major)
- validate-and-store (major)

Bumped Docker image versions to match type of semver bump of underlying Node.